### PR TITLE
Rename bump-deps to update dependencies

### DIFF
--- a/lib/lita/handlers/bumpbot_handler.rb
+++ b/lib/lita/handlers/bumpbot_handler.rb
@@ -82,7 +82,7 @@ module Lita
         help.each do |arg, text|
           complete_help["#{command} PROJECT #{arg}".strip] = text
         end
-        route(/^#{command}\b/, nil, command: true, help: complete_help) do |response|
+        route(/^#{command}(\s|$)/, nil, command: true, help: complete_help) do |response|
           # This block will be instance-evaled in the context of the handler
           # instance - so we can set instance variables etc.
           begin

--- a/lib/lita/handlers/dependency_updater.rb
+++ b/lib/lita/handlers/dependency_updater.rb
@@ -22,16 +22,16 @@ module Lita
       # Chat commands
       #
       command_route(
-        "bump-deps",
-        "Runs the dependency bumper and submits a build if there are new deps"
+        "",
+        "Runs the dependency updater and submits a build if there are new dependencies."
       ) do
         info("Checking for updated dependencies for #{project_name}...")
         update_dependencies
       end
 
       command_route(
-        "forget-bump-deps-builds",
-        "Forget failed bump-deps builds (fixes 'waiting for the quiet period to expire before building again')"
+        "reset dependency updates",
+        "Forget failed dependency update builds (fixes 'waiting for the quiet period to expire before building again')."
       ) do
         project_repo.delete_branch(DEPENDENCY_BRANCH_NAME)
         info("Deleted local branch #{DEPENDENCY_BRANCH_NAME} of #{project_name}.")

--- a/lib/lita_versioner/version.rb
+++ b/lib/lita_versioner/version.rb
@@ -1,3 +1,3 @@
 module LitaVersioner
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This fixes an issue where saying "julia bump-deps chef" actually runs "julia bump chef",