### PR TITLE
Output progress and results as attachments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ group(:style) do
 end
 
 group(:slack) do
-  gem "lita-slack"
+  gem "lita-slack", github: "jkeiser/lita-slack", branch: "send-messages-with-arguments"
 end

--- a/lib/lita/handlers/bumpbot_status_handler.rb
+++ b/lib/lita/handlers/bumpbot_status_handler.rb
@@ -19,11 +19,11 @@ module Lita
           running_handlers.sort_by! { |handler| [ handler.start_time, handler.handler_id.to_i ] }
           running_handlers.reverse!
           attachments = running_handlers.map do |handler|
-            { text: handler.title, ts: handler.start_time.to_i }
+            { color: "warning", text: handler.title, ts: handler.start_time.to_i }
           end
-          output.respond(attachments: attachments)
+          respond(attachments: attachments)
         else
-          output.respond("No command or event handlers are running right now.")
+          respond("No command or event handlers are running right now.")
         end
       end
 
@@ -69,18 +69,22 @@ module Lita
               end
             else
               attachment[:color] = "warning"
-              status = "running"
+              status = "in progress"
             end
             attachment[:text] = "#{title} #{status}. <#{config.lita_url}/bumpbot/handlers/#{handler_id}/handler.log|Log>"
             attachment[:ts] = start_time.to_i
             attachments << attachment
           end
 
-          output.respond("Handlers #{range.min}-#{range.max} of #{handlers.size} displayed. To show the next 10, say \"handlers #{range.max + 1}-#{range.max + 11}\".",
-            attachments: attachments
-          )
+          if range.max < handlers.size
+            attachments << {
+              color: "good",
+              footer: "#{range.min}-#{range.max} of #{handlers.size}, recent first. For more, say `handlers #{range.max + 1}-#{range.max + 11}`.",
+            }
+          end
+          respond(attachments: attachments)
         else
-          output.respond("The system is not running any handlers, and nothing has failed, so there is no handler history to show.")
+          respond("The system is not running any handlers, and nothing has failed, so there is no handler history to show.")
         end
       end
 

--- a/lib/lita/handlers/bumpbot_status_webpage_handler.rb
+++ b/lib/lita/handlers/bumpbot_status_webpage_handler.rb
@@ -10,7 +10,7 @@ module Lita
       # Webpage: /bumpbot/handlers/:id/handler.log
       #
       http.get "/bumpbot/handlers/:id/handler.log" do |request, response|
-        self.http_response = response
+        output.http_response = response
         handler_id = request.env["router.params"][:id]
         handle "Webpage /bumpbot/handlers/#{handler_id}/handler.log" do
           handler_log = File.join(config.sandbox_directory, handler_id.to_s, "handler.log")
@@ -25,7 +25,7 @@ module Lita
               sleep(0.1)
             end
           rescue Errno::ENOENT
-            error!("#{handler_log} not found", status: "404")
+            respond_error!("#{handler_log} not found", status: "404")
           end
         end
       end
@@ -34,12 +34,12 @@ module Lita
       # Webpage: /bumpbot/handlers/:id/sandbox.tgz
       #
       http.get "/bumpbot/handlers/:id/sandbox.tgz" do |request, response|
-        self.http_response = response
+        output.http_response = response
         handler_id = request.env["router.params"][:id]
         handle "Webpage /bumpbot/handlers/#{handler_id}/sandbox.tgz" do
           handler_sandbox = File.join(config.sandbox_directory, handler_id)
           unless File.exist?(handler_sandbox)
-            error!("#{sandbox_directory} not found", status: "404")
+            respond_error!("#{sandbox_directory} not found", status: "404")
           end
           tarfile = File.join(sandbox_directory, "sandbox.tgz")
           run_command "tar czvf #{tarfile} #{handler_sandbox}"

--- a/lib/lita/handlers/dependency_updater.rb
+++ b/lib/lita/handlers/dependency_updater.rb
@@ -30,7 +30,7 @@ module Lita
         "Forget failed dependency update builds (fixes 'waiting for the quiet period to expire before building again')."
       ) do
         project_repo.delete_branch(DEPENDENCY_BRANCH_NAME)
-        info("Deleted local branch #{DEPENDENCY_BRANCH_NAME} of #{project_name}.")
+        output.inform("Deleted local branch #{DEPENDENCY_BRANCH_NAME} of #{project_name}.")
       end
 
       #
@@ -42,8 +42,8 @@ module Lita
       # Event: autobump (update dependencies on timer)
       #
       def update_dependencies_from_timer(proj_name)
+        self.project_name = proj_name
         handle "autobump timer for #{proj_name}" do
-          self.project_name = proj_name
           debug("Running scheduled dependency update for #{project_name}")
           update_dependencies
         end
@@ -71,9 +71,9 @@ module Lita
               handler.update_dependencies_from_timer(project)
             end
           end
-
-          every(config.polling_interval, &timer_fired)
         end
+
+        every(config.polling_interval, &timer_fired)
       end
 
       def update_dependencies
@@ -97,7 +97,7 @@ module Lita
         success = trigger_build("#{project_name}-trigger-ad_hoc", DEPENDENCY_BRANCH_NAME)
         msg = "Started dependency update build for project #{project_name}.\n" +
           "Diff: https://github.com/chef/#{project_name}/compare/auto_dependency_bump_test"
-        info(msg)
+        output.inform(msg)
         true
       end
 

--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -27,9 +27,9 @@ module Lita
         else
           pipeline = "#{project_name}-trigger-ad_hoc"
         end
-        error!("No pipeline specified in project.") unless pipeline
-        success = trigger_build(pipeline, git_ref)
-        output.inform("Kicked off a build for '#{pipeline}' at ref '#{git_ref}'.") if success
+        respond_error!("No pipeline specified in project.") unless pipeline
+        trigger_build(pipeline, git_ref)
+        respond("Kicked off a build for '#{pipeline}' at ref '#{git_ref}'.")
       end
 
       #
@@ -50,78 +50,73 @@ module Lita
       # Handle incoming github events
       #
       def github_handler(request, response)
-        self.http_response = response
-
+        output.http_response = response
         # Filter out events and parse the response
         handle "received github event #{request.params["payload"]}" do
-          payload = JSON.parse(request.params["payload"])
-          repository = payload["repository"]["name"]
-          event_type = request.env["HTTP_X_GITHUB_EVENT"]
-
-          self.project_name = projects.keys.find do |name|
-            repo = File.basename(projects[name][:github_url])
-            repo = repo[0..-4] if repo.end_with?(".git")
-            repo == repository
-          end
-
-          if project_name.nil?
-            error!("Repository '#{repository}' is not monitored by versioner!")
-          end
-
-          debug("Processing '#{event_type}' event for '#{repository}'.")
-
-          # https://developer.github.com/v3/activity/events/types/#pullrequestevent
-          if event_type != "pull_request"
-            debug("Skipping event '#{event_type}' for '#{repository}'. I can only handle 'pull_request' events.")
-            return
-          end
-
-          pull_request_url = payload["pull_request"]["html_url"]
-
-          # If the pull request is merged with some commits
-          if payload["action"] != "closed"
-            debug("Skipping: '#{pull_request_url}' Action: '#{payload["action"]}' Merged? '#{payload["pull_request"]["merged"]}'")
-            return
-          end
-
-          unless payload["pull_request"]["merged"]
-            info("Skipping: '#{pull_request_url}'. It was closed without merging any commits.")
-            return
-          end
-
-          merge_commit_sha = payload["pull_request"]["merge_commit_sha"]
-
-          if project_repo.current_sha != merge_commit_sha
-            warn("Skipping: '#{pull_request_url}'. Latest master is at SHA #{project_repo.current_sha}, but the pull request merged SHA #{merge_commit_sha}")
-            return
-          end
-
-          info("'#{pull_request_url}' was just merged. Bumping version and submitting a build ...")
-
-          # Bump the build in a new handler so we get a good title
-          versioner = Versioner.new(robot)
-          versioner.http_response = response
-          versioner.project_name = project_name
-          versioner.handle "github merged pull request #{pull_request_url} for #{project_name}: #{merge_commit_sha}" do
-            bump_version_and_trigger_build
+          pull_request_url, merge_commit_sha = parse_github_event(request)
+          if pull_request_url
+            versioner = Versioner.from_handler(self)
+            versioner.handle "github merged pull request #{pull_request_url} for #{project_name}: #{merge_commit_sha}" do
+              bump_version_and_trigger_build
+            end
           end
         end
       end
 
-      def bump_version_and_trigger_build
-        new_version = bump_version_in_git
-        output.inform("Bumped version to #{new_version}")
-        git_ref = "v#{new_version}"
-        success = trigger_build(project[:pipeline], git_ref)
-        output.inform("Kicked off release build for '#{project[:pipeline]}' at ref '#{git_ref}'.") if success
+      def parse_github_event(request)
+        payload = JSON.parse(request.params["payload"])
+        repository = payload["repository"]["name"]
+        event_type = request.env["HTTP_X_GITHUB_EVENT"]
+
+        self.project_name = projects.keys.find do |name|
+          repo = File.basename(projects[name][:github_url])
+          repo = repo[0..-4] if repo.end_with?(".git")
+          repo == repository
+        end
+
+        if project_name.nil?
+          respond_error!("Repository '#{repository}' is not monitored by versioner!", http_status_code: "500")
+        end
+
+        debug("Processing '#{event_type}' event for '#{repository}'.")
+
+        # https://developer.github.com/v3/activity/events/types/#pullrequestevent
+        if event_type != "pull_request"
+          debug("Skipping event '#{event_type}' for '#{repository}'. I can only handle 'pull_request' events.")
+          return
+        end
+
+        pull_request_url = payload["pull_request"]["html_url"]
+
+        # If the pull request is merged with some commits
+        if payload["action"] != "closed"
+          debug("Skipping: '#{pull_request_url}' Action: '#{payload["action"]}' Merged? '#{payload["pull_request"]["merged"]}'")
+          return
+        end
+
+        unless payload["pull_request"]["merged"]
+          info("Skipping: '#{pull_request_url}'. It was closed without merging any commits.")
+          return
+        end
+
+        merge_commit_sha = payload["pull_request"]["merge_commit_sha"]
+
+        if project_repo.current_sha != merge_commit_sha
+          warn("Skipping: '#{pull_request_url}'. Latest master is at SHA #{project_repo.current_sha}, but the pull request merged SHA #{merge_commit_sha}")
+          return
+        end
+
+        info("'#{pull_request_url}' was just merged. Bumping version and submitting a build ...")
+
+        [ pull_request_url, merge_commit_sha ]
       end
 
-      def bump_version_in_git
+      def bump_version_and_trigger_build
         project_repo.bump_version
-        project_repo.tag_and_commit
-
-        # we return the version we bumped to
-        project_repo.read_version
+        tag = project_repo.tag_and_commit
+        trigger_build(project[:pipeline], tag)
+        respond("Bumped version of #{project_name} to <#{project_github_url}/tree/#{tag}|#{tag}> and kicked off a release build.")
+        tag
       end
 
       template_root File.expand_path("../../templates", __FILE__)

--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -29,7 +29,7 @@ module Lita
         end
         error!("No pipeline specified in project.") unless pipeline
         success = trigger_build(pipeline, git_ref)
-        info("Kicked off a build for '#{pipeline}' at ref '#{git_ref}'.") if success
+        output.inform("Kicked off a build for '#{pipeline}' at ref '#{git_ref}'.") if success
       end
 
       #
@@ -99,11 +99,10 @@ module Lita
           info("'#{pull_request_url}' was just merged. Bumping version and submitting a build ...")
 
           # Bump the build in a new handler so we get a good title
-          parent = self
           versioner = Versioner.new(robot)
+          versioner.http_response = response
+          versioner.project_name = project_name
           versioner.handle "github merged pull request #{pull_request_url} for #{project_name}: #{merge_commit_sha}" do
-            self.http_response = response
-            self.project_name = parent.project_name
             bump_version_and_trigger_build
           end
         end
@@ -111,10 +110,10 @@ module Lita
 
       def bump_version_and_trigger_build
         new_version = bump_version_in_git
-        info("Bumped version to #{new_version}")
+        output.inform("Bumped version to #{new_version}")
         git_ref = "v#{new_version}"
         success = trigger_build(project[:pipeline], git_ref)
-        info("Kicked off release build for '#{project[:pipeline]}' at ref '#{git_ref}'.") if success
+        output.inform("Kicked off release build for '#{project[:pipeline]}' at ref '#{git_ref}'.") if success
       end
 
       def bump_version_in_git

--- a/lib/lita/handlers/versioner.rb
+++ b/lib/lita/handlers/versioner.rb
@@ -70,7 +70,7 @@ module Lita
 
         self.project_name = projects.keys.find do |name|
           repo = File.basename(projects[name][:github_url])
-          repo = repo[0..-4] if repo.end_with?(".git")
+          repo = repo[0..-5] if repo.end_with?(".git")
           repo == repository
         end
 

--- a/lib/lita_versioner/error_already_reported.rb
+++ b/lib/lita_versioner/error_already_reported.rb
@@ -1,0 +1,10 @@
+module LitaVersioner
+  class ErrorAlreadyReported < StandardError
+    attr_accessor :cause
+
+    def initialize(message = nil, cause = nil)
+      super(message)
+      self.cause = cause
+    end
+  end
+end

--- a/lib/lita_versioner/format_helpers.rb
+++ b/lib/lita_versioner/format_helpers.rb
@@ -23,7 +23,20 @@ module LitaVersioner
     def format_duration(duration)
       minutes, seconds = duration.divmod(60)
       hours, minutes = minutes.divmod(60)
-      "#{"%.2d" % hours}:#{"%.2d" % minutes}:#{"%.2d" % seconds}"
+      days, hours = hours.divmod(24)
+      parts = []
+      parts << "#{days} day#{days > 1 ? "s" : ""}" if days > 0
+      parts << "#{hours} hour#{hours > 1 ? "s" : ""}" if hours > 0
+      parts << "#{minutes} minute#{minutes > 1 ? "s" : ""}" if minutes > 0
+      parts << "#{seconds.to_i} second#{seconds > 1 ? "s" : ""}" if seconds.to_i > 0
+      case parts.size
+      when 0
+        "0 seconds"
+      when 1
+        "#{parts[0]}"
+      else
+        "#{parts[0..-2].join(", ")} and #{parts[-1]}"
+      end
     end
   end
 end

--- a/lib/lita_versioner/handler_output.rb
+++ b/lib/lita_versioner/handler_output.rb
@@ -2,58 +2,172 @@ require_relative "error_already_reported"
 require_relative "format_helpers"
 
 module LitaVersioner
+  #
+  # Handles the rules for output.
+  #
+  # The main output methods are logging (debug, info, warn, error) and responses
+  # (response, inform_success, inform_error, respond_error!, inform). Responses are sent
+  # to Slack as well as the logs.
+  #
+  # While a handler is running, a special "in progress" message will be shown
+  # with the last few lines of log and a link to more. (This will only happen if
+  # the handler takes more than 3 seconds to complete.) The in progress message
+  # will be updated as we go, and deleted when the operation completes.
+  #
   class HandlerOutput
     include FormatHelpers
 
+    # Amount of time to wait (in seconds) before showing the "in progress" message
+    SHOW_IN_PROGRESS_AFTER = 3
+    # Time between progress log updates
+    TIME_BETWEEN_PROGRESS_LOG_UPDATES = 0.1
+    # Number of log lines to show in the "in progress" message.
+    SHOW_LOG_LINES = 10
+
     def initialize(handler)
       @handler = handler
+      @progress_message_mutex = Mutex.new
     end
 
     attr_reader :handler
     attr_accessor :lita_target
     attr_accessor :http_response
+    attr_accessor :status
 
     # Let the user know something about the operation.
-    def inform(message=nil, http_status_code: nil, parse: "none", **slack_message_arguments)
+    def inform(message = nil, http_status_code: nil, **slack_message_arguments)
       # Send data to HTTP response
       if http_response
         http_response.status = http_status_code if http_status_code
-        message = "#{message}\n" unless message.end_with?("\n")
-        http_response.body << message
+        slack_to_messages(message, **slack_message_arguments).each do |message|
+          http_response.body << (message.end_with?("\n") ? message : "#{message}\n")
+        end
       end
 
       # Send a message
       send_message(message, **slack_message_arguments)
-    end
-    alias_method :respond, :inform
 
-    # Let the user know about an error.
-    def inform_error(message=nil, http_status_code: nil, **slack_message_arguments)
+      # Log to info log
+      info(message) if message
+    end
+
+    # Give the user a success message.
+    def inform_success(message = nil, http_status_code: nil, **slack_message_arguments)
+      self.status = :succeeded
+      # Status has changed; update the progress message.
+      update_progress_message
+      # Format message as attachment with green
       if message
         slack_message_arguments[:attachments] = Array(slack_message_arguments[:attachments])
-        slack_message_arguments[:attachments] << { color: "danger", text: message }
+        slack_message_arguments[:attachments] << {
+          color: "good",
+          text: message,
+          mrkdwn_in: [ "text" ],
+        }
       end
       inform(http_status_code: http_status_code, **slack_message_arguments)
+    end
+    alias_method :respond, :inform_success
+
+    # Let the user know about an error.
+    def inform_error(message = nil, http_status_code: nil, **slack_message_arguments)
+      self.status = :failed
+      # Status has changed; update the progress message.
+      update_progress_message
+
+      # Send data to HTTP response
+      if http_response
+        http_response.status = http_status_code if http_status_code
+        slack_to_messages(message, **slack_message_arguments).each do |message|
+          http_response.body << (message.end_with?("\n") ? message : "#{message}\n")
+        end
+      end
+
+      # Format and send message
+      if message
+        slack_message_arguments[:attachments] = Array(slack_message_arguments[:attachments])
+        slack_message_arguments[:attachments] << {
+          color: "danger",
+          text: "#{message}",
+          ts: handler.start_time,
+          footer: "#{(status || "In progress").capitalize}. <#{handler.log_url}|Full log available here.>",
+          mrkdwn_in: [ "text" ],
+        }
+      end
+      send_message(**slack_message_arguments)
+
+      # Log to error log
       error(message)
+
+      update_progress_message
     end
 
     # Let the user know about the error, and raise the error.
-    def error!(message, http_status_code: nil, **slack_message_arguments)
+    def respond_error!(message, http_status_code: nil, **slack_message_arguments)
       inform_error(message, http_status_code: http_status_code, **slack_message_arguments)
       raise ErrorAlreadyReported.new(message)
     end
 
+    # Log an error.
     def error(message)
       log(:error, message)
     end
+
+    # Log a warning.
     def warn(message)
       log(:warn, message)
     end
+
+    # Log an informational message.
     def info(message)
       log(:info, message)
     end
+
+    # Log a debug message.
     def debug(message)
       log(:debug, message)
+    end
+
+    # Used to let us know the handler has officially started and is set up
+    def started
+      self.status = nil
+      # Set the in progress message if we're still running after a while
+      Thread.new do
+        begin
+          sleep SHOW_IN_PROGRESS_AFTER
+          create_progress_message
+        rescue
+          error("Could not create progress message: #{$!}\n#{$!.backtrace.join("\n")}")
+          raise
+        end
+      end
+    end
+
+    # Used to let us know the handler is officially complete
+    def finished
+      self.status ||= :skipped
+      update_progress_message
+    end
+
+    def escape_markdown(text)
+      text = text.gsub("&", "&amp;")
+      text.gsub!("<", "&lt;")
+      text.gsub!(">", "&gt;")
+      text.gsub!(%r{[`*_|=]}) { |c| "&##{c.bytes[0]};" }
+      text
+    end
+
+    def backquote(text)
+      # Haven't figured out a way to backquote a backquote in markdown
+      "`#{text.tr("`", "'")}`"
+    end
+
+    # Output to the same place as another output object. Used by BumpbotHandler.from_handler
+    def inherit_output(other)
+      raise "Cannot inherit output of an unfinished handler!" if other.send(:progress_message_ts)
+      @lita_target = other.lita_target
+      @http_response = other.http_response
+      @status = other.status
     end
 
     private
@@ -62,17 +176,18 @@ module LitaVersioner
     attr_accessor :last_log_level
 
     #
-    # Log to the default Lita logger with a custom per-line prefix.
+    # Log the line to lita, redis and store the last few for the progress message.
     #
-    # This is help identify what command or handler a particular message came
-    # from when reading syslog.
+    # Adds prefixes to each to do things like identify the handler or log level.
     #
     def log(log_level, message)
+      message_lines = message.to_s.lines
       time = Time.now.utc.to_s
 
+      # Store in redis
       log_time = time.to_s
       justified_log_level = log_level.to_s.upcase.ljust(5)
-      log_chunk = message.to_s.lines.map do |line|
+      log_chunk = message_lines.map do |line|
         # After the first line of the output, emit spaces for easier reading
         if log_time == last_log_time
           log_time = " " * log_time.size if log_time == last_log_time
@@ -88,8 +203,15 @@ module LitaVersioner
       end.join("")
       handler.redis.append("handler_logs:#{handler.handler_id}", log_chunk)
 
-      message.to_s.each_line do |l|
+      # Send to lita log
+      message_lines.each do |l|
         handler.log.public_send(log_level, "[#{handler.handler_id}] #{l.chomp}")
+      end
+
+      # Keep last n lines in progress message
+      @progress_log = (progress_log + message_lines).last(SHOW_LOG_LINES).map { |l| l.chomp }
+      unless last_progress_message_update && (Time.now.utc - last_progress_message_update) < TIME_BETWEEN_PROGRESS_LOG_UPDATES
+        update_progress_message
       end
     end
 
@@ -99,21 +221,117 @@ module LitaVersioner
     # - For Slack messages, errors are sent to the originating user via respond
     # - For events, errors are sent to the project.channel_name
     #
-    def send_message(message=nil, **message_arguments)
+    def send_message(message = nil, link_names: 1, parse: "none", **slack_message_arguments)
+      slack_message_arguments[:link_names] = link_names
+      slack_message_arguments[:parse] = parse
       if lita_target
         if Lita.config.robot.adapter == :slack
-          if message
-            handler.robot.chat_service.send_message(lita_target, message, **message_arguments)
-          else
-            handler.robot.chat_service.send_message(lita_target, **message_arguments)
-          end
+          handler.robot.chat_service.send_message(lita_target, message, **slack_message_arguments)
         else
-          handler.robot.send_message(lita_target, message) if message
-          if message_arguments[:attachments]
-            message_arguments[:attachments].each do |attachment|
-              handler.robot.send_message(attachment[:pretext]) if attachment[:pretext]
-              handler.robot.send_message(attachment[:text]) if attachment[:text]
-            end
+          slack_to_messages(message, **slack_message_arguments).each do |message|
+            handler.robot.send_message(lita_target, message)
+          end
+        end
+      end
+    end
+
+    def slack_to_messages(message = nil, **slack_message_arguments)
+      messages = []
+      messages << message if message
+      if slack_message_arguments[:attachments]
+        slack_message_arguments[:attachments].each do |attachment|
+          if attachment[:fallback]
+            messages << attachment[:fallback]
+          else
+            messages << attachment[:title] if attachment[:title]
+            messages << attachment[:text] if attachment[:text]
+            messages << attachment[:footer] if attachment[:footer]
+          end
+        end
+      end
+      messages
+    end
+
+    #
+    # Progress implementation: inform users of handler progress if handlers run
+    # for too long.
+    #
+
+    attr_reader :progress_message_mutex
+    attr_accessor :last_progress_message_update
+    attr_accessor :progress_message_channel
+    attr_accessor :progress_message_ts
+    def progress_log
+      @progress_log ||= []
+    end
+
+    def progress_message(footer_suffix = "")
+      attachment =  {
+        fallback: "#{(status || "In progress").capitalize}: #{handler.title}",
+        title: "#{(status || "In progress").capitalize}: #{handler.title}",
+        ts: handler.start_time.to_i,
+        mrkdwn_in: ["text"],
+      }
+
+      # Do not show the log inline if we're sending to a channel. Only in PM.
+      unless lita_target.is_a?(Lita::Room)
+        log = progress_log.join("\n")
+        log = "```#{log}```" unless log.empty?
+        attachment[:text] = log
+      end
+
+      # Color the attachment based on status
+      case status
+      when :failed
+        attachment[:color] = "danger"
+      when :succeeded
+        attachment[:color] = "good"
+      when :skipped
+      else
+        # In progress
+        attachment[:footer] = "#{(status || "In progress").capitalize}. <#{handler.log_url}|Full log available here.> This message will self-destruct."
+        attachment[:color] = "warning"
+      end
+
+      {
+        attachments: [ attachment ],
+      }
+    end
+
+    # Create the progress message in Slack. This happens after the command has
+    # been running for a while.
+    def create_progress_message
+      progress_message_mutex.synchronize do
+        # Only create the log if we're in progress.
+        if status.nil?
+          if lita_target && Lita.config.robot.adapter == :slack
+            self.last_progress_message_update = Time.now.utc
+            result = handler.robot.chat_service.send_message(lita_target, **progress_message)
+            self.progress_message_channel = result["channel"]
+            self.progress_message_ts = result["ts"]
+          end
+        end
+      end
+    end
+
+    # Update the progress message in Slack (if it's there). If the command is
+    # finished, this deletes it.
+    def update_progress_message
+      # We synchronize the mutex to eliminate race conditions where the message
+      # is created after we've made the decision to delete them, or we attempt
+      # to update a message that's already been deleted.
+      progress_message_mutex.synchronize do
+        if progress_message_ts
+          if status
+            # If we're finished, delete the progress message.
+            handler.robot.chat_service.delete_message(progress_message_channel, progress_message_ts)
+            self.last_progress_message_update = Time.now.utc
+            self.progress_message_channel = nil
+            self.progress_message_ts = nil
+          else
+            # Otherwise, update it.
+            self.last_progress_message_update = Time.now.utc
+            handler.robot.chat_service.update_message(progress_message_channel, progress_message_ts, **progress_message)
           end
         end
       end

--- a/lib/lita_versioner/handler_output.rb
+++ b/lib/lita_versioner/handler_output.rb
@@ -1,0 +1,122 @@
+require_relative "error_already_reported"
+require_relative "format_helpers"
+
+module LitaVersioner
+  class HandlerOutput
+    include FormatHelpers
+
+    def initialize(handler)
+      @handler = handler
+    end
+
+    attr_reader :handler
+    attr_accessor :lita_target
+    attr_accessor :http_response
+
+    # Let the user know something about the operation.
+    def inform(message=nil, http_status_code: nil, parse: "none", **slack_message_arguments)
+      # Send data to HTTP response
+      if http_response
+        http_response.status = http_status_code if http_status_code
+        message = "#{message}\n" unless message.end_with?("\n")
+        http_response.body << message
+      end
+
+      # Send a message
+      send_message(message, **slack_message_arguments)
+    end
+    alias_method :respond, :inform
+
+    # Let the user know about an error.
+    def inform_error(message=nil, http_status_code: nil, **slack_message_arguments)
+      if message
+        slack_message_arguments[:attachments] = Array(slack_message_arguments[:attachments])
+        slack_message_arguments[:attachments] << { color: "danger", text: message }
+      end
+      inform(http_status_code: http_status_code, **slack_message_arguments)
+      error(message)
+    end
+
+    # Let the user know about the error, and raise the error.
+    def error!(message, http_status_code: nil, **slack_message_arguments)
+      inform_error(message, http_status_code: http_status_code, **slack_message_arguments)
+      raise ErrorAlreadyReported.new(message)
+    end
+
+    def error(message)
+      log(:error, message)
+    end
+    def warn(message)
+      log(:warn, message)
+    end
+    def info(message)
+      log(:info, message)
+    end
+    def debug(message)
+      log(:debug, message)
+    end
+
+    private
+
+    attr_accessor :last_log_time
+    attr_accessor :last_log_level
+
+    #
+    # Log to the default Lita logger with a custom per-line prefix.
+    #
+    # This is help identify what command or handler a particular message came
+    # from when reading syslog.
+    #
+    def log(log_level, message)
+      time = Time.now.utc.to_s
+
+      log_time = time.to_s
+      justified_log_level = log_level.to_s.upcase.ljust(5)
+      log_chunk = message.to_s.lines.map do |line|
+        # After the first line of the output, emit spaces for easier reading
+        if log_time == last_log_time
+          log_time = " " * log_time.size if log_time == last_log_time
+        else
+          self.last_log_time = log_time
+        end
+        if justified_log_level == last_log_level
+          justified_log_level = " " * justified_log_level.size if justified_log_level == last_log_level
+        else
+          self.last_log_level = justified_log_level
+        end
+        "[#{log_time} #{justified_log_level}] #{line.chomp}\n"
+      end.join("")
+      handler.redis.append("handler_logs:#{handler.handler_id}", log_chunk)
+
+      message.to_s.each_line do |l|
+        handler.log.public_send(log_level, "[#{handler.handler_id}] #{l.chomp}")
+      end
+    end
+
+    #
+    # Send a message to the appropriate place.
+    #
+    # - For Slack messages, errors are sent to the originating user via respond
+    # - For events, errors are sent to the project.channel_name
+    #
+    def send_message(message=nil, **message_arguments)
+      if lita_target
+        if Lita.config.robot.adapter == :slack
+          if message
+            handler.robot.chat_service.send_message(lita_target, message, **message_arguments)
+          else
+            handler.robot.chat_service.send_message(lita_target, **message_arguments)
+          end
+        else
+          handler.robot.send_message(lita_target, message) if message
+          if message_arguments[:attachments]
+            message_arguments[:attachments].each do |attachment|
+              handler.robot.send_message(attachment[:pretext]) if attachment[:pretext]
+              handler.robot.send_message(attachment[:text]) if attachment[:text]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lita_versioner/project_repo.rb
+++ b/lib/lita_versioner/project_repo.rb
@@ -74,17 +74,19 @@ module LitaVersioner
 
     def tag_and_commit
       version = read_version
+      tag = "v#{version}"
 
       ensure_git_config_set
 
       run_command(%w{git add -A})
       run_command(%w{git commit -m} + ["Bump version of #{repo_name} to #{version} by Chef Versioner."])
-      run_command(%W{git tag -a v#{version} -m} + ["Version tag for #{version}."])
+      run_command(%W{git tag -a #{tag} -m} + ["Version tag for #{version}."])
       begin
         run_command(%w{git push origin master --tags})
+        tag
       rescue
         # We need to cleanup the local tag we have created if the push has failed.
-        run_command(%W{git tag -d v#{version}})
+        run_command(%W{git tag -d #{tag}})
         raise
       end
     end

--- a/spec/integration/lita/handlers/dependency_updater_spec.rb
+++ b/spec/integration/lita/handlers/dependency_updater_spec.rb
@@ -28,8 +28,9 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
         send_command("update dependencies")
 
         expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          **ERROR:** No project specified!
+          No project specified!
           Usage: update dependencies PROJECT   - Runs the dependency updater and submits a build if there are new dependencies.
+          Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
         EOM
       end
 
@@ -37,8 +38,9 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
         send_command("update dependencies blarghle")
 
         expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          **ERROR:** Invalid project blarghle. Valid projects: lita-test.
+          Invalid project blarghle. Valid projects: lita-test.
           Usage: update dependencies PROJECT   - Runs the dependency updater and submits a build if there are new dependencies.
+          Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
         EOM
       end
 
@@ -46,8 +48,9 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
         send_command("update dependencies lita-test blarghle")
 
         expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          **ERROR:** Too many arguments (2 for 1)!
+          Too many arguments (2 for 1)!
           Usage: update dependencies PROJECT   - Runs the dependency updater and submits a build if there are new dependencies.
+          Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
         EOM
       end
     end
@@ -99,9 +102,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
               send_command("update dependencies lita-test")
 
               expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                Checking for updated dependencies for lita-test...
-                Started dependency update build for project lita-test.
-                Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
               EOM
 
               expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("A")
@@ -116,9 +117,8 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  dependencies on master are up to date
-                  **ERROR:** Dependency update build not triggered: dependencies on master are up to date
+                  Dependency update build not triggered: dependencies on master are up to date
+                  Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
                 EOM
                 expect(git_file(git_remote, "deps.txt")).to eq("A")
               end
@@ -131,9 +131,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  Started dependency update build for project lita-test.
-                  Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                  <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
                 EOM
 
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("A")
@@ -159,9 +157,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
               send_command("update dependencies lita-test")
 
               expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                Checking for updated dependencies for lita-test...
-                Started dependency update build for project lita-test.
-                Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
               EOM
 
               expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("A")
@@ -194,9 +190,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
               send_command("update dependencies lita-test")
 
               expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                Checking for updated dependencies for lita-test...
-                Started dependency update build for project lita-test.
-                Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
               EOM
 
               expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("A")
@@ -228,9 +222,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  Started dependency update build for project lita-test.
-                  Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                  <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
                 EOM
 
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("A")
@@ -261,8 +253,6 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  WARN: Dependency update build not triggered: conflicting build in progress.
                 EOM
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("Y")
               end
@@ -291,8 +281,6 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  WARN: Dependency update build not triggered: conflicting build in progress.
                 EOM
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("Y")
               end
@@ -320,8 +308,6 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  WARN: Dependency update build not triggered: conflicting build in progress.
                 EOM
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("Y")
               end
@@ -348,8 +334,6 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  WARN: Dependency update build not triggered: conflicting build in progress.
                 EOM
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("Y")
               end
@@ -381,8 +365,6 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
                 send_command("update dependencies lita-test")
 
                 expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                  Checking for updated dependencies for lita-test...
-                  WARN: Dependency update build not triggered: conflicting build in progress.
                 EOM
                 expect(git_file(git_remote, "deps.txt", ref: "auto_dependency_bump_test")).to eq("Y")
               end
@@ -415,9 +397,7 @@ describe Lita::Handlers::DependencyUpdater, lita_handler: true, additional_lita_
               send_command("update dependencies lita-test")
 
               expect(reply_string).to eq(strip_eom_block(<<-EOM))
-                Checking for updated dependencies for lita-test...
-                Started dependency update build for project lita-test.
-                Diff: https://github.com/chef/lita-test/compare/auto_dependency_bump_test
+                <https://github.com/chef/lita-test/compare/auto_dependency_bump_test|Updated dependencies> and triggered ad-hoc build for project lita-test.
               EOM
             end
           end

--- a/spec/integration/lita/handlers/versioner_spec.rb
+++ b/spec/integration/lita/handlers/versioner_spec.rb
@@ -39,26 +39,29 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
     it "build with no arguments emits a reasonable error message" do
       send_command("build")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** No project specified!
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        No project specified!
         Usage: build PROJECT [GIT_REF]   - Kicks off a build for PROJECT with GIT_REF. GIT_REF default: master.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
     it "build blarghle emits a reasonable error message" do
       send_command("build blarghle")
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** Invalid project blarghle. Valid projects: lita-test.
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Invalid project blarghle. Valid projects: lita-test.
         Usage: build PROJECT [GIT_REF]   - Kicks off a build for PROJECT with GIT_REF. GIT_REF default: master.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
     it "build lita-test master blarghle does not build (too many arguments)" do
       send_command("build lita-test master blarghle")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** Too many arguments (3 for 2)!
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Too many arguments (3 for 2)!
         Usage: build PROJECT [GIT_REF]   - Kicks off a build for PROJECT with GIT_REF. GIT_REF default: master.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
@@ -67,7 +70,7 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
       send_command("build lita-test")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
         Kicked off a build for 'lita-test-trigger-release' at ref 'master'.
       EOM
     end
@@ -77,7 +80,7 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
       send_command("build lita-test example")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
         Kicked off a build for 'lita-test-trigger-ad_hoc' at ref 'example'.
       EOM
     end
@@ -87,27 +90,30 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
     it "build with no arguments emits a reasonable error message" do
       send_command("bump")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** No project specified!
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        No project specified!
         Usage: bump PROJECT   - Bumps the version of PROJECT and starts a build.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
     it "build blarghle emits a reasonable error message" do
       send_command("bump blarghle")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** Invalid project blarghle. Valid projects: lita-test.
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Invalid project blarghle. Valid projects: lita-test.
         Usage: bump PROJECT   - Bumps the version of PROJECT and starts a build.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
     it "bump lita-test blarghle does not bump (too many arguments)" do
       send_command("bump lita-test blarghle")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        **ERROR:** Too many arguments (2 for 1)!
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Too many arguments (2 for 1)!
         Usage: bump PROJECT   - Bumps the version of PROJECT and starts a build.
+        Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
       EOM
     end
 
@@ -116,9 +122,8 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
       send_command("bump lita-test")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        Bumped version to AA
-        Kicked off release build for 'lita-test-trigger-release' at ref 'vAA'.
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Bumped version of lita-test to </TMPDIR/lita-test/tree/vAA|vAA> and kicked off a release build.
       EOM
 
       expect(git_file(git_remote, "file.txt")).to eq("AA")
@@ -137,11 +142,11 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
     #   send_command("bump lita-test")
     #   t.join
     #
-    #   expect(reply_string).to eq(strip_eom_block(<<-EOM))
+    #   expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
     #     Bumped version to AA
-    #     Kicked off release build for 'lita-test-trigger-release' at ref 'vAA'.
+    #     Bumped version of lita-test to </TMPDIR/lita-test/tree/vAA|vAA> and kicked off a release build.
     #     Bumped version to AA
-    #     Kicked off release build for 'lita-test-trigger-release' at ref 'vAA'.
+    #     Bumped version of lita-test to </TMPDIR/lita-test/tree/vAA|vAA> and kicked off a release build.
     #   EOM
     #
     #   expect(git_file(git_remote, "file.txt")).to eq("AA")
@@ -166,11 +171,9 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
       send_command("bump lita-test")
 
-      expect(reply_string).to eq(strip_eom_block(<<-EOM))
-        Bumped version to AA
-        Kicked off release build for 'lita-test-trigger-release' at ref 'vAA'.
-        Bumped version to AAA
-        Kicked off release build for 'lita-test-trigger-release' at ref 'vAAA'.
+      expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+        Bumped version of lita-test to </TMPDIR/lita-test/tree/vAA|vAA> and kicked off a release build.
+        Bumped version of lita-test to </TMPDIR/lita-test/tree/vAAA|vAAA> and kicked off a release build.
       EOM
 
       expect(git_file(git_remote, "file.txt")).to eq("AAA")
@@ -204,7 +207,7 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
         expect(git_file(git_remote, "file.txt")).to eq("A")
 
         expect(replies).to be_empty
-        expect(response.body).to eq(reply_string)
+        expect(strip_log_data(response.body)).to eq(reply_string)
       end
     end
 
@@ -214,8 +217,9 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
         expect(response.status).to eq(500)
         expect(git_file(git_remote, "file.txt")).to eq("A")
 
-        expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          **ERROR:** Repository 'blarghle' is not monitored by versioner!
+        expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+          Repository 'blarghle' is not monitored by versioner!
+          Failed. <http://localhost:8080/bumpbot/handlers/1/handler.log|Full log available here.>
         EOM
       end
     end
@@ -237,10 +241,9 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
         expect(response.status).to eq(200)
         expect(git_file(git_remote, "file.txt")).to eq("A")
 
-        expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          Skipping: 'https://github.com/chef/lita-test/pulls/1'. It was closed without merging any commits.
+        expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
         EOM
-        expect(response.body).to eq(reply_string)
+        expect(strip_log_data(response.body)).to eq(reply_string)
       end
     end
 
@@ -255,12 +258,12 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
         expect(git_file(git_remote, "file.txt")).to eq("ZA")
 
-        expect(reply_string).to eq(strip_eom_block(<<-EOM))
-          'https://github.com/chef/lita-test/pulls/1' was just merged. Bumping version and submitting a build ...
-          Bumped version to ZA
-          Kicked off release build for 'lita-test-trigger-release' at ref 'vZA'.
+        expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+          Bumped version of lita-test to </TMPDIR/lita-test/tree/vZA|vZA> and kicked off a release build.
         EOM
-        expect(response.body).to eq(reply_string)
+        expect(strip_log_data(response.body)).to eq(strip_eom_block(<<-EOM))
+          Bumped version of lita-test to </TMPDIR/lita-test/tree/vZA|vZA> and kicked off a release build.
+        EOM
       end
 
       it "when another commit has been created before the merge is triggered, it fails to push but then handles the next merge" do
@@ -269,7 +272,7 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
 
         response = post_github_event("pull_request", "lita-test", "closed", true, sha: sha1)
         expect(response.status).to eq(200)
-        expect(response.body.strip).to eq("WARN: Skipping: 'https://github.com/chef/lita-test/pulls/1'. Latest master is at SHA 5a6d2b42c1d26c11616a4c07eb44ead0483661ae, but the pull request merged SHA 23da147c3c4244d787a02e792d7649c6b5ad7acd")
+        expect(response.body.strip).to eq("")
 
         expect(git_file(git_remote, "file.txt")).to eq("ZZ")
 
@@ -279,13 +282,13 @@ describe Lita::Handlers::Versioner, lita_handler: true, additional_lita_handlers
         expect(response2.status).to eq(200)
 
         expect(git_file(git_remote, "file.txt")).to eq("ZZA")
-        expect(response2.body).to eq(strip_eom_block(<<-EOM))
-          'https://github.com/chef/lita-test/pulls/2' was just merged. Bumping version and submitting a build ...
-          Bumped version to ZZA
-          Kicked off release build for 'lita-test-trigger-release' at ref 'vZZA'.
+        expect(strip_log_data(response2.body)).to eq(strip_eom_block(<<-EOM))
+          Bumped version of lita-test to </TMPDIR/lita-test/tree/vZZA|vZZA> and kicked off a release build.
         EOM
 
-        expect(reply_string).to eq("#{response.body}#{response2.body}")
+        expect(strip_log_data(reply_string)).to eq(strip_eom_block(<<-EOM))
+          Bumped version of lita-test to </TMPDIR/lita-test/tree/vZZA|vZZA> and kicked off a release build.
+        EOM
       end
     end
   end

--- a/spec/support/lita_helpers.rb
+++ b/spec/support/lita_helpers.rb
@@ -49,7 +49,7 @@ module Lita
     class TestWaitHandler < BumpbotHandler
       command_route "test wait", "Waits until signalled.", max_args: 1, project_arg: false do |failure|
         wait_for.wait(mutex)
-        error!(failure) if failure
+        respond_error!(failure) if failure
       end
 
       def initialize(*args)
@@ -70,7 +70,7 @@ module Lita
 
     class TestCommandHandler < BumpbotHandler
       command_route "test command", "Runs through, or fails if given a message to fail with.", max_args: 1, project_arg: false do |failure|
-        error!(failure) if failure
+        respond_error!(failure) if failure
       end
     end
   end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -6,4 +6,15 @@ module SpecHelpers
       block
     end
   end
+
+  TIMESTAMP_SIZE = "2016-06-07 02:45:52 UTC ".size
+  def strip_log_data(log)
+    log = log.gsub(/^\[.{#{TIMESTAMP_SIZE}}/, "[")
+    log.gsub(tmpdir, "/TMPDIR")
+  end
+
+  # Allow things to take 1 second extra and still match
+  def one_second_slop(log)
+    log.gsub("after 1 second", "after 0 seconds")
+  end
 end


### PR DESCRIPTION
- Don't display warnings and informational messages in channel
- Display a "progress message" while handlers are running that streams the logs (only streams in PM)
- Display success and error messages as attachments so they have color and are distinguishable from other messages
- Link to full logs on error and in progress